### PR TITLE
Split request queue into pending and in progress

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -58,23 +58,24 @@ class App extends Component {
         </div>
       );
     } else if (this.state.user) {
-      // contents = (
-      //   <div>
-      //     <RequestForm
-      //       user={this.state.user.uid}
-      //       complete={request => this.setState({ request })}
-      //     />
-      //     <SignOut />
-      //   </div>
-      // );
-      contents = (
-        <div>
-          <RequestQueue
-            user={this.state.user}
-          />
-          <SignOut />
-        </div>
-      );
+        if (this.state.isDispatcher) {
+          contents = (
+            <div>
+              <RequestQueue />
+              <SignOut />
+            </div>
+          );
+        } else {
+          contents = (
+            <div>
+              <RequestForm
+                user={this.state.user.uid}
+                complete={request => this.setState({ request })}
+              />
+              <SignOut />
+            </div>
+          );
+        }
     }
 
     const isSignedIn = this.state.user;

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -13,18 +13,27 @@ import RequestQueue from './RequestQueue';
 class App extends Component {
   constructor(props) {
     super(props);
-
     this.state = {
       user: null,
       request: null,
+      isDispatcher: false,
     };
   }
 
   componentDidMount() {
     firebase.auth.onAuthStateChanged(user => {
-      user
-        ? this.setState({ user })
-        : this.setState({ user: null });
+      if (user) {
+        this.setState({ user });
+        const db = firebase.firebase.firestore();
+        db.collection('users').doc(user.uid).get()
+        .then(doc => {
+          const isDispatcher = doc.data().role === 'dispatcher';
+          this.setState({ isDispatcher });
+        })
+        .catch(error => console.log(error));
+      } else {
+        this.setState({ user: null });
+      }
     });
   }
 
@@ -49,7 +58,6 @@ class App extends Component {
         </div>
       );
     } else if (this.state.user) {
-      console.log(this.state.user)
       // contents = (
       //   <div>
       //     <RequestForm
@@ -61,7 +69,9 @@ class App extends Component {
       // );
       contents = (
         <div>
-          <RequestQueue />
+          <RequestQueue
+            user={this.state.user}
+          />
           <SignOut />
         </div>
       );

--- a/src/components/CancelRequest.js
+++ b/src/components/CancelRequest.js
@@ -18,7 +18,7 @@ class CancelRequestButton extends Component {
       console.log('Document successfully deleted.');
     })
     .catch(error => {
-      this.setState({ error: error });
+      this.setState({ error });
     });
     event.preventDefault();
     this.props.complete();

--- a/src/components/CancelRequest.js
+++ b/src/components/CancelRequest.js
@@ -11,13 +11,15 @@ class CancelRequestButton extends Component {
 
   onClick = (event) => {
     const db = firebase.firestore();
-    db.collection('requests').doc(this.props.id).delete()
-      .then(() => {
-        console.log('Document successfully deleted.');
-      })
-      .catch(error => {
-        this.setState({ error: error })
-      })
+    db.collection('requests').doc(this.props.id).update({
+      active: false
+    })
+    .then(() => {
+      console.log('Document successfully deleted.');
+    })
+    .catch(error => {
+      this.setState({ error: error });
+    });
     event.preventDefault();
     this.props.complete();
   }

--- a/src/components/CancelRequest.js
+++ b/src/components/CancelRequest.js
@@ -12,7 +12,7 @@ class CancelRequestButton extends Component {
   onClick = (event) => {
     const db = firebase.firestore();
     db.collection('requests').doc(this.props.id).update({
-      active: false
+      state: 'cancelled'
     })
     .then(() => {
       console.log('Document successfully deleted.');

--- a/src/components/RequestForm.js
+++ b/src/components/RequestForm.js
@@ -30,7 +30,7 @@ class RequestForm extends Component {
       from: this.state.from,
       to: this.state.to,
       user: this.props.user,
-      active: true,
+      state: 'pending',
     }
     db.collection('requests').add(
       request

--- a/src/components/RequestQueue.js
+++ b/src/components/RequestQueue.js
@@ -12,7 +12,7 @@ class RequestQueue extends Component {
   componentDidMount() {
     let requests = [];
     const db = firebase.firestore();
-    db.collection('requests').get()
+    db.collection('requests').where('active', '==', true).get()
     .then(querySnapshot => {
       querySnapshot.forEach(doc => {
         requests.push(

--- a/src/components/RequestQueue.js
+++ b/src/components/RequestQueue.js
@@ -12,13 +12,20 @@ class RequestQueue extends Component {
   componentDidMount() {
     let requests = [];
     const db = firebase.firestore();
-    db.collection('requests').where('active', '==', true).get()
+    db.collection('requests').where('state', '==', 'pending').get()
     .then(querySnapshot => {
       querySnapshot.forEach(doc => {
         requests.push(
           Object.assign({}, { id: doc.id }, doc.data())
         );
       })
+      db.collection('requests').where('state', '==', 'in progress').get()
+      .then(querySnapshot => {
+        querySnapshot.forEach(doc => {
+          requests.push(
+            Object.assign({}, { id: doc.id }, doc.data())
+          );
+        })
       this.setState({ requests });
     });
   }

--- a/src/components/RequestQueue.js
+++ b/src/components/RequestQueue.js
@@ -61,29 +61,64 @@ class RequestQueue extends Component {
     event.preventDefault();
   }
 
+  makeSatisfied = (event, id) => {
+    const db = firebase.firestore();
+    db.collection('requests').doc(id).update({
+      state: 'satisfied'
+    })
+    .then(() => {
+      const updatedRequests = this.state.requests.filter(request => request.id !== id);
+      this.setState({ requests: updatedRequests })
+    });
+    event.preventDefault();
+  }
+
   render() {
     if (this.state.requests) {
       const pendingRequests = this.state.requests.filter(request => request.state === 'pending');
       const inProgressRequests = this.state.requests.filter(request => request.state === 'in progress');
       return (
-        <table>
-          <tbody>
-            {pendingRequests.map(request => (
-              <tr key={request.user}>
-                <td>{request.name}</td>
-                <td>{request.passengers}</td>
-                <td>{request.from}</td>
-                <td>{request.to}</td>
-                <button onClick={event => this.makeInProgress(event, request.id)}>
-                Pick Up
-                </button>
-                <button onClick={event => this.cancelRequest(event, request.id)}>
-                Cancel Request
-                </button>
-              </tr>
-            ))}
-          </tbody>
-        </table>
+        <div>
+          <table>
+            <caption><b>Pending Requests</b></caption>
+            <tbody>
+              {pendingRequests.map(request => (
+                <tr key={request.user}>
+                  <td>{request.name}</td>
+                  <td>{request.passengers}</td>
+                  <td>{request.from}</td>
+                  <td>{request.to}</td>
+                  <button onClick={event => this.makeInProgress(event, request.id)}>
+                  Pick Up
+                  </button>
+                  <button onClick={event => this.cancelRequest(event, request.id)}>
+                  Cancel Request
+                  </button>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+          <br/>
+          <table>
+            <caption><b>In Progress Requests</b></caption>
+            <tbody>
+              {inProgressRequests.map(request => (
+                <tr key={request.user}>
+                  <td>{request.name}</td>
+                  <td>{request.passengers}</td>
+                  <td>{request.from}</td>
+                  <td>{request.to}</td>
+                  <button onClick={event => this.makeSatisfied(event, request.id)}>
+                  Drop Off
+                  </button>
+                  <button onClick={event => this.cancelRequest(event, request.id)}>
+                  Cancel Request
+                  </button>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
       );
     }
     return null;

--- a/src/components/RequestQueue.js
+++ b/src/components/RequestQueue.js
@@ -25,11 +25,13 @@ class RequestQueue extends Component {
 
   deleteRequest = (event, id) => {
     const db = firebase.firestore();
-    db.collection('requests').doc(id).delete()
-      .then(() => {
-        console.log('Document successfully deleted.');
-        // update requests in state
-      })
+    db.collection('requests').doc(id).update({
+      active: false
+    })
+    .then(() => {
+      const requests = this.state.requests.filter(request => request.id !== id);
+      this.setState({ requests })
+    });
     event.preventDefault();
   }
 

--- a/src/components/RequestQueue.js
+++ b/src/components/RequestQueue.js
@@ -19,13 +19,15 @@ class RequestQueue extends Component {
           Object.assign({}, { id: doc.id }, doc.data())
         );
       })
-      db.collection('requests').where('state', '==', 'in progress').get()
-      .then(querySnapshot => {
-        querySnapshot.forEach(doc => {
-          requests.push(
-            Object.assign({}, { id: doc.id }, doc.data())
-          );
-        })
+      this.setState({ requests });
+    });
+    db.collection('requests').where('state', '==', 'in progress').get()
+    .then(querySnapshot => {
+      querySnapshot.forEach(doc => {
+        requests.push(
+          Object.assign({}, { id: doc.id }, doc.data())
+        );
+      })
       this.setState({ requests });
     });
   }

--- a/src/components/SignIn.js
+++ b/src/components/SignIn.js
@@ -22,7 +22,7 @@ class SignInButton extends Component {
         // history.push('/home');
       })
       .catch(error => {
-        this.setState({ error: error })
+        this.setState({ error })
       })
 
     event.preventDefault();

--- a/src/firebase/firebase.js
+++ b/src/firebase/firebase.js
@@ -1,5 +1,6 @@
 import firebase from 'firebase';
 import 'firebase/auth';
+import 'firebase/firestore';
 
 const config = {
   apiKey: "AIzaSyBzmV2bS-FVMCYq8KR-hj2W0Hw04Q_MGUs",
@@ -22,9 +23,12 @@ const auth = firebase.auth();
 //   auth,
 // };
 
+const db = firebase.firestore();
+
 export {
   firebase,
   auth,
+  db,
 };
 
 // export default firebase;


### PR DESCRIPTION
This PR adds new request states `pending`, `in progress`, `satisfied`, and `cancelled`. It conditionally renders the request queue, now split into a 'pending' queue and an 'in progress' queue, based on if the authenticated user is a dispatcher, and it adds a button to each pending request to set its state to `in progress` and to each in progress request to set its state to `satisfied`.